### PR TITLE
Stop mboot.c32 from clobbering SysLINUX on module relocation

### DIFF
--- a/include/x86/cpu.h
+++ b/include/x86/cpu.h
@@ -34,9 +34,6 @@ typedef struct CPUIDRegs {
    unsigned int eax, ebx, ecx, edx;
 } CPUIDRegs;
 
-CPUIDRegs cpuid0;
-CPUIDRegs cpuid1;
-
 #define CPUID_FAMILY_P6 6
 #define CPUID_FAMILY_EXTENDED 15
 

--- a/mboot/reloc.c
+++ b/mboot/reloc.c
@@ -729,8 +729,7 @@ static int blacklist_bootloader_mem(UNUSED_PARAM(e820_range_t *mmap),
    size_t i;
 
 #if defined(__COM32__)
-   status = blacklist_runtime_mem((run_addr_t)PTR_TO_UINT(__executable_start),
-                                  _end - __executable_start);
+   status = blacklist_runtime_mem(0, PTR_TO_UINT64(_end));
    if (status != ERR_SUCCESS) {
       Log(LOG_ERR, "Loader memory reservation error.\n");
       return status;

--- a/mboot/x86/system_arch.c
+++ b/mboot/x86/system_arch.c
@@ -80,6 +80,9 @@ CPUID_IsVendorIntel(CPUIDRegs *id0)
 void
 check_cpu_quirks(void)
 {
+   CPUIDRegs cpuid0;
+   CPUIDRegs cpuid1;
+
    __GET_CPUID(0, &cpuid0);
    __GET_CPUID(1, &cpuid1);
    is_intel_skylake = (CPUID_IsVendorIntel(&cpuid0) &&

--- a/uefi/elf2efi/Makefile
+++ b/uefi/elf2efi/Makefile
@@ -14,7 +14,7 @@ HOST_CFLAGS += -Wno-stringop-truncation
 
 all: $(BUILD_DIR) $(ELF2EFI)
 
-$(ELF2EFI): elf2efi.c $(HOST_LIBBFD) $(HOST_LIBERTY) $(HOST_LIBCRYPTO)
+$(ELF2EFI): elf2efi.c $(HOST_LIBBFD) $(HOST_LIBERTY) $(HOST_LIBCRYPTO) $(HOST_LIBZ)
 	$(call print,CC,$@)
 	$(HOST_CC) $(HOST_CFLAGS) -O2 $(patsubst %,-I%,$(INC)) -o $@ $^ \
 		-lpthread -ldl

--- a/uefi/elf2efi/elf2efi.c
+++ b/uefi/elf2efi/elf2efi.c
@@ -41,6 +41,12 @@
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
+#ifndef bfd_get_section_flags
+# define bfd_get_section_flags(bfd, section) bfd_section_flags((section))
+# define bfd_get_section_vma(bfd, section) bfd_section_vma((section))
+# define bfd_section_size(bfd, section) bfd_section_size((section))
+#endif /* ifndef bfd_get_section_flags */
+
 #define eprintf(...) fprintf ( stderr, __VA_ARGS__ )
 
 #define EFI_FILE_ALIGN 0x20


### PR DESCRIPTION
The SysLINUX memory from 0x100000 - _exectuable_start for mboot.c32 should be in the blacklist so that relocations don't clobber it.  If it gets clobbered the next Log() will try to jump to the clobbered SysLINUX console service and hang the system.